### PR TITLE
feat(gherkin): parse and propagate Scenario/Scenario Outline descript…

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,16 @@
         "repositoryURL": "https://github.com/apple/swift-docc-plugin",
         "state": {
           "branch": null,
-          "revision": "3303b164430d9a7055ba484c8ead67a52f7b74f6",
+          "revision": "3e4f133a77e644a5812911a0513aeb7288b07d06",
+          "version": "1.4.5"
+        }
+      },
+      {
+        "package": "SymbolKit",
+        "repositoryURL": "https://github.com/swiftlang/swift-docc-symbolkit",
+        "state": {
+          "branch": null,
+          "revision": "b45d1f2ed151d057b54504d653e0da5552844e34",
           "version": "1.0.0"
         }
       }

--- a/Sources/CucumberSwift/DSL/DSLScenarioOutline.swift
+++ b/Sources/CucumberSwift/DSL/DSLScenarioOutline.swift
@@ -13,6 +13,7 @@ public struct ScenarioOutline: ScenarioDSL {
 
     @discardableResult public init<T>(_ title: String,
                                       tags: [String] = [],
+                                      description: String = "",
                                       headers: T.Type,
                                       line: UInt = #line,
                                       column: UInt = #column,
@@ -21,6 +22,7 @@ public struct ScenarioOutline: ScenarioDSL {
         scenarios = examples().map {
             Scenario(with: steps($0),
                      title: title,
+                     description: description,
                      tags: tags,
                      position: Lexer.Position(line: line, column: column))
         }
@@ -28,6 +30,7 @@ public struct ScenarioOutline: ScenarioDSL {
 
     @discardableResult public init<T>(_ title: String,
                                       tags: [String] = [],
+                                      description: String = "",
                                       headers: T.Type,
                                       line: UInt = #line,
                                       column: UInt = #column,
@@ -36,6 +39,7 @@ public struct ScenarioOutline: ScenarioDSL {
         scenarios = examples().map {
             Scenario(with: [steps($0)],
                      title: title,
+                     description: description,
                      tags: tags,
                      position: Lexer.Position(line: line, column: column))
         }
@@ -43,6 +47,7 @@ public struct ScenarioOutline: ScenarioDSL {
 
     @discardableResult public init<T>(_ title: (T) -> String,
                                       tags: [String] = [],
+                                      description: String = "",
                                       headers: T.Type,
                                       line: UInt = #line,
                                       column: UInt = #column,
@@ -51,6 +56,7 @@ public struct ScenarioOutline: ScenarioDSL {
         scenarios = examples().map {
             Scenario(with: steps($0),
                      title: title($0),
+                     description: description,
                      tags: tags,
                      position: Lexer.Position(line: line, column: column))
         }
@@ -58,6 +64,7 @@ public struct ScenarioOutline: ScenarioDSL {
 
     @discardableResult public init<T>(_ title: (T) -> String,
                                       tags: [String] = [],
+                                      description: String = "",
                                       headers: T.Type,
                                       line: UInt = #line,
                                       column: UInt = #column,
@@ -66,6 +73,7 @@ public struct ScenarioOutline: ScenarioDSL {
         scenarios = examples().map {
             Scenario(with: [steps($0)],
                      title: title($0),
+                     description: description,
                      tags: tags,
                      position: Lexer.Position(line: line, column: column))
         }

--- a/Sources/CucumberSwift/DSL/ScenarioDSL.swift
+++ b/Sources/CucumberSwift/DSL/ScenarioDSL.swift
@@ -28,17 +28,28 @@ public protocol ScenarioDSL {
 
 extension Scenario {
     public convenience init(_ title: String,
+                            description: String = "",
                             tags: [String] = [],
                             line: UInt = #line,
                             column: UInt = #column,
                             @StepBuilder _ content: () -> [StepDSL]) {
-        self.init(with: content(), title: title, tags: tags, position: Lexer.Position(line: line, column: column))
+        self.init(with: content(),
+                  title: title,
+                  description: description,
+                  tags: tags,
+                  position: Lexer.Position(line: line, column: column))
     }
     public convenience init(_ title: String,
+                            description: String = "",
                             tags: [String] = [],
                             line: UInt = #line,
                             column: UInt = #column,
                             @StepBuilder _ content: () -> StepDSL) {
-        self.init(with: [content()], title: title, tags: tags, position: Lexer.Position(line: line, column: column))
+        self.init(with: [content()],
+                  title: title,
+                  description: description,
+                  tags: tags,
+                  position: Lexer.Position(line: line, column: column))
     }
 }
+// swiftlint:enable file_types_order

--- a/Sources/CucumberSwift/Gherkin/Parser/Scenario.swift
+++ b/Sources/CucumberSwift/Gherkin/Parser/Scenario.swift
@@ -10,7 +10,8 @@ import Foundation
 public class Scenario: NSObject, Taggable, Positionable {
     public private(set)  var title = ""
     public internal(set)  var tags = [String]()
-    public internal(set) var steps = [Step]()
+    public internal(set)  var steps = [Step]()
+    public internal(set) var desc: String = ""
     public internal(set) var feature: Feature?
     public private(set)  var location: Lexer.Position
     public private(set)  var endLocation: Lexer.Position
@@ -19,11 +20,14 @@ public class Scenario: NSObject, Taggable, Positionable {
     init(with node: AST.ScenarioNode, tags: [String], stepNodes: [AST.StepNode]) {
         location = node.tokens.first?.position ?? .start
         endLocation = .start
+        desc = ""
         super.init()
         self.tags = tags
         for token in node.tokens {
             if case Lexer.Token.title(_, let t) = token {
                 title = t
+            } else if case Lexer.Token.description(_, let t) = token {
+                desc += t + "\n"
             } else if case Lexer.Token.tag(_, let tag) = token {
                 self.tags.append(tag)
             }
@@ -34,12 +38,13 @@ public class Scenario: NSObject, Taggable, Positionable {
         endLocation ?= steps.last?.location
     }
 
-    init(with steps: [Step], title: String?, tags: [String], position: Lexer.Position) {
+    init(with steps: [Step], title: String?, description: String? = "", tags: [String], position: Lexer.Position) {
         location = position
         endLocation = position
         super.init()
         self.steps = steps
         self.title = title ?? ""
+        self.desc = description ?? ""
         self.tags = tags
         setupSteps()
     }
@@ -68,7 +73,7 @@ public class Scenario: NSObject, Taggable, Positionable {
             "keyword": "Scenario",
             "type": "scenario",
             "name": title,
-            "description": "",
+            "description": desc,
             "steps": []
         ]
     }

--- a/Tests/CucumberSwiftTests/Gherkin/ParserTests.swift
+++ b/Tests/CucumberSwiftTests/Gherkin/ParserTests.swift
@@ -340,5 +340,34 @@ class ParserTests: XCTestCase {
         XCTAssertEqual(scenarios[safe: 1]?.steps.first?.match, "there are 20 cucumbers")
         XCTAssertEqual(scenarios[safe: 1]?.steps.last?.match, "I should have 15 cucumbers")
     }
+
+    func testWhitespaceOnlyFeatureDescriptionIsIgnored() {
+        let cucumber = Cucumber(withString: """
+    Feature: Feature with whitespace description
+       \n\n         \t   \n\n
+       Scenario: Basic
+         Given a step
+    """)
+        let feature = cucumber.features.first
+        XCTAssertEqual(feature?.title, "Feature with whitespace description")
+        // Whitespace-only description should not be parsed/preserved
+        XCTAssertEqual(feature?.desc, "")
+        XCTAssertEqual(feature?.scenarios.count, 1)
+    }
+
+    func testSpecialCharactersInFeatureDescriptionArePreserved() {
+        let cucumber = Cucumber(withString: """
+    Feature: Internationalization
+       Café naïve résumé — emojis: 😀🚀, Chinese: 中文, Arabic: العربية
+       Accents: áéíóú ÁÉÍÓÚ ü Ü ñ Ñ ç Ç
+
+       Scenario: Basic
+         Given a step
+    """)
+        let feature = cucumber.features.first
+        XCTAssertEqual(feature?.title, "Internationalization")
+        let expected = "Café naïve résumé — emojis: 😀🚀, Chinese: 中文, Arabic: العربية\nAccents: áéíóú ÁÉÍÓÚ ü Ü ñ Ñ ç Ç\n"
+        XCTAssertEqual(feature?.desc, expected)
+    }
 }
 // swiftlint:enable type_body_length type_contents_order


### PR DESCRIPTION
This pull request adds support for parsing and propagating scenario descriptions in both regular Scenarios and Scenario Outlines within the CucumberSwift framework. Descriptions defined in Gherkin files are now correctly parsed and attached to their corresponding `Scenario` objects, including those generated from Scenario Outlines. Comprehensive tests have been added to verify this behavior.

### Scenario description parsing and propagation

* The `Scenario` class now includes a `desc` property to hold the scenario description, and its initializer and serialization logic have been updated to use this property. [[1]](diffhunk://#diff-692497c85f3c93fa5f0d00201219d8b852002d9bc94807a5e4abf09fde4a2e03R14) [[2]](diffhunk://#diff-692497c85f3c93fa5f0d00201219d8b852002d9bc94807a5e4abf09fde4a2e03L37-R47) [[3]](diffhunk://#diff-692497c85f3c93fa5f0d00201219d8b852002d9bc94807a5e4abf09fde4a2e03L71-R76)
* The scenario parser extracts description lines from Gherkin files and attaches them to the corresponding `Scenario` objects.

### Scenario Outline description handling

* The scenario outline parser extracts description lines from Scenario Outline blocks and propagates them to each expanded example scenario. [[1]](diffhunk://#diff-497e88f5fb23847f2612604378ff4df9e20125d9eb6200efe195302786fb504eR19-R78) [[2]](diffhunk://#diff-497e88f5fb23847f2612604378ff4df9e20125d9eb6200efe195302786fb504eR95) [[3]](diffhunk://#diff-497e88f5fb23847f2612604378ff4df9e20125d9eb6200efe195302786fb504eL78-R124)
* The `ScenarioOutline` DSL initializer and expansion logic now accept and propagate a `description` parameter to each scenario. [[1]](diffhunk://#diff-5f813378863b2909dc8de8611ce946c1a3588be3926ad3eee673bc245470e927R16) [[2]](diffhunk://#diff-5f813378863b2909dc8de8611ce946c1a3588be3926ad3eee673bc245470e927R25-R33) [[3]](diffhunk://#diff-5f813378863b2909dc8de8611ce946c1a3588be3926ad3eee673bc245470e927R42-R50) [[4]](diffhunk://#diff-5f813378863b2909dc8de8611ce946c1a3588be3926ad3eee673bc245470e927R59-R67) [[5]](diffhunk://#diff-5f813378863b2909dc8de8611ce946c1a3588be3926ad3eee673bc245470e927R76)

### Testing

* New tests verify that scenario and scenario outline descriptions are parsed and attached correctly, and that step parsing remains correct.

### DSL and protocol updates

* The `ScenarioDSL` protocol and DSL convenience initializers now support an optional `description` parameter.…ions

- Add `desc` to `Scenario` and include it in exported JSON (`description` field)
- Parse `.description` tokens in `Scenario` and Scenario Outline bodies
- Propagate Scenario Outline description to each expanded Scenario
- Extend DSL initializers to accept `description:` (default empty) and wire through
- Update `ScenarioOutlineParser` to extract outline description (trims leading/trailing empty lines, preserves inner ones)
- Add tests for scenario and outline descriptions, including value substitution
- Fix SwiftLint: trailing_closure, and local disables for long line/type_body_length where necessary
- Bump `swift-docc-plugin` to 1.4.5 and add `SymbolKit` to Package.resolved

Refs: parsing, DSL, tests